### PR TITLE
Developers don't care to change the registering comment of a block. T…

### DIFF
--- a/Developer Mistakes/DevCause Developer's Mistakes.md
+++ b/Developer Mistakes/DevCause Developer's Mistakes.md
@@ -1,0 +1,5 @@
+# DevCause Developer's Mistakes
+
+## WordPress Blocks
+
+* [ ] Developers don't care to change the registering comment of a block. That is always set to previous one copied. In this case `// register a ACFBlock`


### PR DESCRIPTION
…hat is always set to previous one copied. In this case // register a ACFBlock